### PR TITLE
Currency conversion fix

### DIFF
--- a/app/models/base_models.py
+++ b/app/models/base_models.py
@@ -76,8 +76,7 @@ class AssetAnalysis():
                     raise ValueError(
                         f"No history data after converting `{self.__ticker}` to currency `{currency_ticker}`")
 
-                self.__history['Close'] = self.__history['Close'] * \
-                    self.__history['currency_close']
+                self.__history['Close'] = self.__history['Close'] / self.__history['currency_close']
                 self.__history.drop(columns=['currency_close'], inplace=True)
 
             self.__expires = self.__info.get('expireIsoDate') is not None

--- a/app/routes/risk_routes.py
+++ b/app/routes/risk_routes.py
@@ -20,7 +20,10 @@ async def get_ticker_data(ticker: str, currency: str | None = None):
     # cache_key = construct_cache_key(CacheKey.TICKER_METRICS, ticker)
 
     try:
-        initial_asset_data = await create_asset_analysis(ticker, period="10y", currency=currency)
+        initial_asset_data = await create_asset_analysis(
+            ticker,
+            period="15y",
+            currency=currency)
 
     except Exception as e:
         raise HTTPException(status_code=400, detail=str(e)) from e


### PR DESCRIPTION
This pull request introduces two key changes: it corrects the currency conversion logic in historical price data and extends the analysis period for asset data retrieval from 10 years to 15 years. These updates improve both the accuracy of financial calculations and the comprehensiveness of the data provided.

**Data accuracy improvements:**
* Fixed the calculation of asset closing prices in `BaseModel.init` by dividing `Close` by `currency_close` instead of multiplying, ensuring correct currency conversion for historical data.

**Data coverage enhancements:**
* Updated `get_ticker_data` in `risk_routes.py` to fetch asset analysis over a 15-year period instead of 10 years, providing a longer historical context for risk assessments.